### PR TITLE
chore: pass limit through kernel.call to _collectStream

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -430,7 +430,7 @@ class NetKernel extends EventEmitter {
    * });
    *
    */
-  call(node, event, data, cb, timeout=Infinity) {
+  call(node, event, data, cb, timeout=Infinity, limit = 10000000) {
     const id = this._generateToken();
     const rstream = this._rstream(node, id, timeout);
 
@@ -444,7 +444,7 @@ class NetKernel extends EventEmitter {
     }
 
     if (typeof cb === "function") {
-      NetKernel._collectStream(rstream, cb);
+      NetKernel._collectStream(rstream, cb, limit);
     }
     return rstream;
   }


### PR DESCRIPTION
`_collectStream` can take a `limit` as an parameter. The `limit` parameter has a default value of 10MB. The only call to `_collectStream` from `call` in kernel.js didn't take a `limit` parameter. This made it a hardcoded limit.

Now it's not hardcoded and a `limit` can be passed through.